### PR TITLE
0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+0.1.25
+* CHANGE: Minimum boat move default increased from 50m to 80m
+* CHANGE: Updated the README.md
+* Final version after successful testing SV MOIN and SV KIAPA NUI
+
 0.1.25-beta.3
-* NEW: Check if boat key ist set on startup, else report error to dashboard
+* NEW: Check if boat key is set on startup, else report error to dashboard
 * CHANGE: Changing the order and label of the Plugin Settings to make it more clear for unexpierienced users and grouped to Mandatory, Advanced and Expert.
 * CHANGE: Migration of < 0.1.25 Plugin settings to new structure.
 * CHANGE: PluginStatus last track sent "Never" changed to "Not transfered since plugin start" to avoid confusions.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 # SignalK To NFL
 Effortlessly log your boat's movement to **noforeignland.com**
 
-## Testing Notes
-- This version includes experimental features
-- Report issues on GitHub
-- Not recommended for production use
-
-
 ## Features
 * Automatically log your position to NFL
 * Send detailed tracks to log your entire trip and not just your final position
 * Can be used in near real time or cache and upload when stopped and data-connection is available.
+* Can sent a 24h keepalive, when off the boat for a while.
 
-An internet connection is required in order to update NFL.
+## Issues
+* Report issues on GitHub (https://github.com/noforeignland/nfl-signalk/issues)
 
 ## Requirements
+* An internet connection is required in order to update NFL.
+* A navigation.position data path inside Signal K for self, which is your current GPS position
 * A **noforeignland.com** account
 * Your Boat API Key from the **noforeignland.com** website: 
   * Account > Settings > Boat tracking > API Key
 
 > Note your Boat API Key is not available in the app. 
 > You must sign in to the **noforeignland.com** website (using the same authentication method you use for the app: Google. Facebook, Email).
+
+## Configuration
+1. Add your boat's API Key into the Server > Plugin Config > Signal K to Noforeignland > Boat API Key
+2. Hit "Submit"
+3. Restart the Signal K server 

--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ getSchema() {
         properties: {
           boatApiKey: {
             type: 'string',
-            title: 'Boat API key',
-            description: 'Boat API key from noforeignland.com. Can be found in Account > Settings > Boat tracking > API Key.'
+            title: 'Boat API Key',
+            description: 'Boat API Key from noforeignland.com. Can be found in Account > Settings > Boat tracking > API Key.'
           }
         }
       },
@@ -59,7 +59,7 @@ getSchema() {
             type: 'number',
             title: 'Minimum boat move to log in meters',
             description: 'To keep file sizes small we only log positions if a move larger than this size (if set to 0 will log every move)',
-            default: 50
+            default: 80
           },
           minSpeed: {
             type: 'number',
@@ -194,7 +194,7 @@ getSchema() {
     boatApiKey: options.mandatory?.boatApiKey,
     
     // Advanced defaults
-    minMove: options.advanced?.minMove !== undefined ? options.advanced.minMove : 50,
+    minMove: options.advanced?.minMove !== undefined ? options.advanced.minMove : 80,
     minSpeed: options.advanced?.minSpeed !== undefined ? options.advanced.minSpeed : 1.5,
     sendWhileMoving: options.advanced?.sendWhileMoving !== undefined ? options.advanced.sendWhileMoving : true,
     ping_api_every_24h: options.advanced?.ping_api_every_24h !== undefined ? options.advanced.ping_api_every_24h : true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-to-noforeignland",
-  "version": "0.1.25-beta.3",
+  "version": "0.1.25",
   "description": "SignalK track logger to noforeignland.com ",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
0.1.25
* CHANGE: Minimum boat move default increased from 50m to 80m
* CHANGE: Updated the README.md
* Final version after successful testing SV MOIN and SV KIAPA NUI

0.1.25-beta.3
* NEW: Check if boat key is set on startup, else report error to dashboard
* CHANGE: Changing the order and label of the Plugin Settings to make it more clear for unexpierienced users and grouped to Mandatory, Advanced and Expert.
* CHANGE: Migration of < 0.1.25 Plugin settings to new structure.
* CHANGE: PluginStatus last track sent "Never" changed to "Not transfered since plugin start" to avoid confusions.


0.1.25-beta.2
* CHANGE: Typo in pluginName fixed
* CHANGE: Dates for SetPlugin now ISO8601 formated (https://github.com/noforeignland/nfl-signalk/issues/9)

0.1.25-beta.1
* CHANGE: User mattzilla470 reported timout Issues on VE Cerbo with a small CPU and using 4G (https://github.com/noforeignland/nfl-signalk/issues/7). So added a timout option in the plugin config and a tripple retry while increasing the timeout for the API call.