### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.0
+* NEW: Signal K Appstore metadata — displayName, appIcon and screenshots are now shown in the Appstore card and detail page (#21)
+* NEW: Agent/contributor guide AGENTS.md (with CLAUDE.md symlink)
+
 1.2.1
 * FIX: Replace cryptic "The user aborted a request" timeout error with human-readable "Request timed out after Xs" message (#17)
 * CHANGE: Convert jest.config.js to TypeScript, add ts-node devDependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noforeignland/signalk-to-noforeignland",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noforeignland/signalk-to-noforeignland",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "cron": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "./doc/screenshots/2_nfl_phone-7.jpg"
     ]
   },
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "SignalK track logger to noforeignland.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Minor version bump for the Signal K Appstore metadata feature.

## Summary
- `package.json` / `package-lock.json`: 1.2.1 → 1.3.0
- `CHANGELOG.md`: entry for 1.3.0 covering the Appstore metadata (#21) and the AGENTS.md addition

## Tested
- `npm pack --dry-run` reports `version: 1.3.0`, `filename: noforeignland-signalk-to-noforeignland-1.3.0.tgz`, tarball 167.8 kB.

Once merged, tagging `v1.3.0` triggers the publish workflow (OIDC trusted publisher → npm).