### PR TITLE
chore(ci): bump actions to v6 and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Pacific/Auckland
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # node-fetch@3+ is ESM-only; this project compiles to CommonJS.
+      # Pinned to v2.x intentionally — see src/lib/TrackSender.ts.
+      - dependency-name: node-fetch
+        update-types: [version-update:semver-major]
+      - dependency-name: '@types/node-fetch'
+        update-types: [version-update:semver-major]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Pacific/Auckland
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - ci
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Clean workspace
         run: git clean -xfd
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` → `v6` and `actions/setup-node@v4` → `v6` in both `ci.yml` and `publish.yml`. v6 runs on Node 24, which is the required runtime starting 2026-06-02 per GitHub's deprecation of Node 20 runners (this exact annotation showed up on the v1.3.0 publish run).
- Adds `.github/dependabot.yml` covering both ecosystems:
  - **npm** and **github-actions**, weekly Monday 06:00 NZST.
  - Minor + patch updates grouped per ecosystem to cut PR noise; majors get their own PRs so they can be reviewed.
  - `node-fetch` and `@types/node-fetch` major bumps are ignored — v3+ is ESM-only and this project compiles to CommonJS, so an upgrade would require non-trivial restructuring.
  - Commit prefix `chore` to match the repo's Angular convention.

## Tested
- `grep -nE "actions/(checkout|setup-node)@" .github/workflows/*.yml` shows all four refs on `v6`.
- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly.
- `cr review --plain` ran against the diff — no findings.
- Live verification has to wait for merge: CI runs on this PR will already exercise the v6 actions, and the dependabot config is only evaluated by GitHub after it lands on `main`.

## Note on branch naming
Dependabot's PR branches always start with `dependabot/...` (slashes are hardcoded by Dependabot itself, no opt-out). I'm flagging this because hyphenated branches are the local convention — these are framework-generated and there's no way to disable the prefix.