### PR TITLE
ci: auto-create GitHub Release on v* tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -38,9 +38,33 @@ jobs:
       - run: npm test
 
       - name: Publish
-        run: | 
+        run: |
           if [[ "${{ github.ref }}" == refs/tags/*-beta.* ]] || [[ "${{ github.ref }}" == refs/tags/*-rc.* ]]; then
             npm publish --provenance --access public --tag beta
           else
             npm publish --provenance --access public
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          NOTES_FILE="$(mktemp)"
+          awk -v v="$VERSION" '
+            $0 == v { in_section = 1; next }
+            in_section && /^[0-9]+\.[0-9]+\.[0-9]+/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+
+          PRERELEASE_FLAG=""
+          if [[ "$TAG" == *-beta.* ]] || [[ "$TAG" == *-rc.* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          if [[ -s "$NOTES_FILE" ]]; then
+            gh release create "$TAG" --title "$VERSION" --notes-file "$NOTES_FILE" $PRERELEASE_FLAG
+          else
+            gh release create "$TAG" --title "$VERSION" --generate-notes $PRERELEASE_FLAG
           fi


### PR DESCRIPTION
## Why
`publish.yml` has been publishing to npm for years but never created a matching **GitHub Release** object — only `npm publish` runs on a `v*` tag, so the Releases tab on the repo only ever showed manually-created releases. After v1.3.0 shipped to npm, the Releases page still said "Latest: 1.2.1" until I backfilled the v1.3.0 release by hand.

## Summary
Adds a `Create GitHub Release` step at the end of the publish job:

- Promotes `permissions.contents` from `read` to `write` so the workflow token can call the Releases API.
- Extracts the section for the current tag from `CHANGELOG.md` using an awk pass keyed on the bare version line, terminated by the next `X.Y.Z` heading.
- Falls back to `gh release create --generate-notes` when there's no matching CHANGELOG entry, so a hotfix tag without a CHANGELOG update still produces a release rather than failing the workflow.
- Flags `*-beta.*` / `*-rc.*` tags as prereleases, mirroring the existing npm dist-tag logic in the `Publish` step.
- Runs **after** `Publish` so a GitHub Release can never point at a non-existent npm version.

## Tested
- Awk extractor validated locally against the real `CHANGELOG.md`:
  - `1.3.0` → "NEW: Signal K Appstore metadata …" + "NEW: Agent/contributor guide AGENTS.md …"
  - `1.2.1` → "FIX: Replace cryptic …" + "CHANGE: Convert jest.config.js …"
  - `1.2.0-beta.5` → "FIX: Remove composite:true …"
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` parses cleanly.
- `cr review --plain` — no findings.
- v1.3.0 itself was backfilled manually with `gh release create v1.3.0` already; this workflow change takes effect on the next tag push.