### PR TITLE
fix: attach cause to thrown errors in DirectoryUtils and TrackSender

### DIFF
--- a/src/lib/DirectoryUtils.ts
+++ b/src/lib/DirectoryUtils.ts
@@ -26,7 +26,7 @@ export function createDir(dir: string, app: DebugLogger): boolean {
     } catch (error: unknown) {
       const err = error as NodeJS.ErrnoException;
       app.debug('[createDir]', err.message);
-      throw new Error(`No rights to directory ${dir}`);
+      throw new Error(`No rights to directory ${dir}`, { cause: error });
     }
   } else {
     try {
@@ -38,13 +38,13 @@ export function createDir(dir: string, app: DebugLogger): boolean {
         case 'EACCES':
         case 'EPERM':
           app.debug(`Failed to create ${dir} by Permission denied`);
-          throw new Error(`Failed to create ${dir} by Permission denied`);
+          throw new Error(`Failed to create ${dir} by Permission denied`, { cause: error });
         case 'ETIMEDOUT':
           app.debug(`Failed to create ${dir} by Operation timed out`);
-          throw new Error(`Failed to create ${dir} by Operation timed out`);
+          throw new Error(`Failed to create ${dir} by Operation timed out`, { cause: error });
         default:
           app.debug(`Error creating directory ${dir}: ${err.message}`);
-          throw new Error(`Error creating directory ${dir}: ${err.message}`);
+          throw new Error(`Error creating directory ${dir}: ${err.message}`, { cause: error });
       }
     }
   }

--- a/src/lib/TrackSender.ts
+++ b/src/lib/TrackSender.ts
@@ -172,7 +172,7 @@ export class TrackSender {
 
         if (!shouldRetry || attempt === maxRetries) {
           // Don't retry client errors or if we've exhausted retries
-          throw new Error(message);
+          throw new Error(message, { cause: err });
         } else {
           const waitTime = 2000 * attempt;
           this.app.debug(`Waiting ${String(waitTime)}ms before retry...`);


### PR DESCRIPTION
## Why
Several `catch (err) { ... throw new Error(...) }` blocks build a new Error from a message but drop the original on the floor. The ES2022 `{ cause }` option exists specifically for this — it keeps the underlying stack reachable on `.cause` for diagnostics without changing the surfaced message.

Salvaged from the closed Dependabot PR #28 (`@eslint/js@10`), which would have made `preserve-caught-error` a recommended-rule failure. The bump itself is blocked on the eslint 10 peer chain (same wall as #29), but this code change is a defensive improvement worth landing regardless.

## Summary
- `DirectoryUtils.ts`: 4 throws in `createDir()` — the R_OK/W_OK access failure and the EACCES/EPERM, ETIMEDOUT, default cases of `mkdir`.
- `TrackSender.ts`: 1 throw — the retry-exhausted path in `sendWithRetry()`.

No behavioural change. Error messages and retry semantics are identical.

## Tested
- `npm run validate` — typecheck + lint + 44 tests + 100% coverage, all green.
- `npm run format:check` — clean.
- `cr review --plain` — no findings.