### PR TITLE
ci: add .gitattributes with eol=lf for Windows runners

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Force LF in the working tree on every platform so prettier --check passes
+# on Windows runners — .prettierrc inherits Prettier 3's endOfLine: "lf" default.
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary


### PR DESCRIPTION
Fixes the Windows-side failures of the new SignalK Plugin CI workflow (introduced in #35).

## Diagnosis
On `actions/checkout` Windows runners, text files are checked out with CRLF. `prettier --check` then fails on **all 19 .ts files** because `.prettierrc` inherits Prettier 3's `endOfLine: "lf"` default. The PR run for #35 (job 78155564362) shows:

```
> @noforeignland/signalk-to-noforeignland@1.3.0 format:check
> prettier --check "src/**/*.ts" "test/**/*.ts"
[warn] src/index.ts
[warn] src/lib/ConfigManager.ts
… 17 more …
[warn] Code style issues found in 19 files. Run Prettier with --write to fix.
##[error]Process completed with exit code 1.
```

Linux x64/arm64 and macOS were unaffected because their default checkout already uses LF.

## Fix
`.gitattributes` with `* text=auto eol=lf` forces LF in the working tree on every platform — the repo-wide canonical fix. Plus the common binary types tagged `binary` so git never tries to normalise them.

## Tested
- `git add --renormalize .` on the current Linux tree produces **no changes** (everything is already LF; nothing to rewrite).
- `npm run validate` and `npm run format:check` still green locally.
- `cr review --plain` — no findings.
- Live cross-platform verification: this PR itself triggers the SignalK plugin-ci workflow, so we'll see whether Windows turns green before merge.