### PR TITLE
chore(release): 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.3.1
+* CHANGE: Bump cron 3 → 4 for Node 24 compatibility (#31)
+* CHANGE: Attach `cause` to thrown errors in DirectoryUtils and TrackSender for better diagnostics (#34)
+* CHANGE: CI now runs across Linux x64/arm64, macOS and Windows on Node 22/24 via the shared SignalK plugin-ci workflow (#35, #36)
+* CHANGE: Auto-create GitHub Release on `v*` tag push (#26)
+* CHANGE: Bump grouped minor/patch dependencies (typescript-eslint 8.60, @signalk/server-api 2.25, prettier 3.8.3, ts-jest, fs-extra) (#27)
+
 1.3.0
 * NEW: Signal K Appstore metadata — displayName, appIcon and screenshots are now shown in the Appstore card and detail page (#21)
 * NEW: Agent/contributor guide AGENTS.md (with CLAUDE.md symlink)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noforeignland/signalk-to-noforeignland",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noforeignland/signalk-to-noforeignland",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "./doc/screenshots/2_nfl_phone-7.jpg"
     ]
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "SignalK track logger to noforeignland.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release covering the dependency and CI improvements that have accumulated since 1.3.0. No user-facing behavioural changes, but worth shipping so users get the cron v4 upgrade and the more thoroughly tested lockfile.

## Summary
- `package.json` / `package-lock.json`: 1.3.0 → 1.3.1
- `CHANGELOG.md`: entry for 1.3.1 covering the cron 4 bump (#31), the `cause:` additions (#34), the shared SignalK plugin-ci workflow (#35) + Windows line-endings fix (#36), the auto-GitHub-Release workflow step (#26), and the grouped minor/patch deps (#27).

## Tested
- `npm pack --dry-run` reports `version: 1.3.1`, `filename: noforeignland-signalk-to-noforeignland-1.3.1.tgz`, tarball 167.8 kB (unchanged from 1.3.0 — same asset set).

Once merged, tagging `v1.3.1` triggers `publish.yml`. This is the first release that exercises the auto-GitHub-Release step added in #26, so the Releases tab should populate without manual backfill this time.