### PR TITLE
fix(health): derive staleness threshold from trackFrequency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ noforeignland.savepoint_local        Locale string of the same
 noforeignland.sent_to_api            ISO8601 of last successful upload
 noforeignland.sent_to_api_local      Locale string of the same
 noforeignland.status                 Human-readable status
-noforeignland.status_boolean         0 = OK, 1 = error (drives notification)
+noforeignland.status_boolean         0 = OK, 1 = error (no notification emitted; users set Zones if they want one)
 noforeignland.source                 Active GNSS source name
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@ Effortlessly log your boat's movement to **noforeignland.com**
 
 ## Data paths created by this plugin
 ```
-noforeignland.savepoint                    - ISO8601 timestamp - when was last point saved to trackfile
-noforeignland.savepoint_local              - locale timestamp  - when was last point saved to trackfile
-noforeignland.sent_to_api                  - ISO8601 timestamp - last successful transfer to the API
-noforeignland.sent_to_api_local            - locale timestamp  - last successful transfer to the API
-noforeignland.status                       - string            - Status & Error messages
-noforeignland.status_boolean               - number            - 0 = normal operation, 1 = error
-noforeignland.source - string              - string            - data source of navigation.position
-notifications.noforeignland.status_boolean - json object       - auto created
+noforeignland.savepoint         - ISO8601 timestamp - when was last point saved to trackfile
+noforeignland.savepoint_local   - locale timestamp  - when was last point saved to trackfile
+noforeignland.sent_to_api       - ISO8601 timestamp - last successful transfer to the API
+noforeignland.sent_to_api_local - locale timestamp  - last successful transfer to the API
+noforeignland.status            - string            - Status & Error messages
+noforeignland.status_boolean    - number            - 0 = normal operation, 1 = error
+noforeignland.source            - string            - data source of navigation.position
 ```
+
+To get a Signal K notification when the plugin enters the error state, add a Zone rule on `noforeignland.status_boolean` (Server → Data Browser → the path → "Set Zones"): treat values `>= 1` as `alarm` (or `alert`). The plugin itself does not emit any `notifications.*` deltas.
 
 ## Development
 

--- a/src/lib/HealthMonitor.ts
+++ b/src/lib/HealthMonitor.ts
@@ -11,15 +11,33 @@ import type {
   OnHealthyCallback,
 } from '../types';
 
+const BASE_STALE_THRESHOLD_SECONDS = 300;
+const TRACK_FREQUENCY_HEADROOM_SECONDS = 60;
+
+/**
+ * Compute the staleness threshold from the configured trackFrequency.
+ * navigation.position is subscribed with `minPeriod: trackFrequency * 1000`,
+ * so the plugin only sees one delivery per trackFrequency window. We need at
+ * least two windows of headroom before declaring the source dead, otherwise
+ * any user with trackFrequency >= 150s gets false "No GNSS position data"
+ * errors on a perfectly healthy GNSS.
+ */
+export function computeStaleThresholdSeconds(trackFrequencySeconds: number): number {
+  const derived = trackFrequencySeconds * 2 + TRACK_FREQUENCY_HEADROOM_SECONDS;
+  return Math.max(BASE_STALE_THRESHOLD_SECONDS, derived);
+}
+
 export class HealthMonitor {
   private app: SignalKApp;
   private options: FlatConfig;
   private checkInterval: ReturnType<typeof setInterval> | null = null;
   private initialTimeout: ReturnType<typeof setTimeout> | null = null;
+  private staleThresholdSeconds: number;
 
   constructor(app: SignalKApp, options: FlatConfig) {
     this.app = app;
     this.options = options;
+    this.staleThresholdSeconds = computeStaleThresholdSeconds(options.trackFrequency);
   }
 
   /**
@@ -75,7 +93,10 @@ export class HealthMonitor {
 
       onError(errorMsg);
       this.app.debug('Position health check: No position data ever received' + filterMsg);
-    } else if (timeSinceLastPosition !== null && timeSinceLastPosition > 300) {
+    } else if (
+      timeSinceLastPosition !== null &&
+      timeSinceLastPosition > this.staleThresholdSeconds
+    ) {
       const errorMsg = this.options.filterSource
         ? `No GNSS position data${filterMsg} for ${String(Math.floor(timeSinceLastPosition / 60))} minutes. Check that source '${this.options.filterSource}' is active, or change/clear Position source device in Expert Settings.`
         : `No GNSS position data${filterMsg} for ${String(Math.floor(timeSinceLastPosition / 60))} minutes. Check your GNSS connection.`;

--- a/test/unit/HealthMonitor.test.ts
+++ b/test/unit/HealthMonitor.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for HealthMonitor staleness threshold.
+ *
+ * Regression: with `trackFrequency >= ~150s`, the old hardcoded 300s threshold
+ * tripped routinely because navigation.position deltas are throttled to one
+ * delivery per trackFrequency window. See issue #38.
+ */
+
+import { HealthMonitor, computeStaleThresholdSeconds } from '../../src/lib/HealthMonitor';
+import { createMockApp } from '../mocks/signalk-app';
+import type { FlatConfig } from '../../src/types';
+
+function makeConfig(overrides: Partial<FlatConfig> = {}): FlatConfig {
+  return {
+    boatApiKey: 'k',
+    minMove: 50,
+    minSpeed: 0,
+    sendWhileMoving: true,
+    ping_api_every_24h: true,
+    trackDir: '/tmp/x',
+    keepFiles: false,
+    trackFrequency: 60,
+    apiCron: '*/10 * * * *',
+    apiTimeout: 30,
+    maxVelocity: 50,
+    ...overrides,
+  };
+}
+
+describe('computeStaleThresholdSeconds', () => {
+  it('keeps the 300s floor for small trackFrequency', () => {
+    expect(computeStaleThresholdSeconds(0)).toBe(300);
+    expect(computeStaleThresholdSeconds(60)).toBe(300);
+    expect(computeStaleThresholdSeconds(119)).toBe(300);
+  });
+
+  it('scales above 300s once trackFrequency * 2 + 60 exceeds it', () => {
+    expect(computeStaleThresholdSeconds(120)).toBe(300);
+    expect(computeStaleThresholdSeconds(150)).toBe(360);
+    expect(computeStaleThresholdSeconds(600)).toBe(1260);
+  });
+});
+
+describe('HealthMonitor.performHealthCheck', () => {
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not error on a 599s gap when trackFrequency is 600 (issue #38 regression)', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig({ trackFrequency: 600 }));
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.performHealthCheck(NOW - 599_000, null, onError, onHealthy);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onHealthy).toHaveBeenCalled();
+  });
+
+  it('still errors when the gap exceeds the derived threshold', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig({ trackFrequency: 600 }));
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.performHealthCheck(NOW - 1_400_000, null, onError, onHealthy);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onHealthy).not.toHaveBeenCalled();
+  });
+
+  it('errors at the legacy 300s threshold when trackFrequency is low', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig({ trackFrequency: 60 }));
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.performHealthCheck(NOW - 600_000, null, onError, onHealthy);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onHealthy).not.toHaveBeenCalled();
+  });
+
+  it('errors when lastPositionReceived is null', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig());
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.performHealthCheck(null, null, onError, onHealthy);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('No GNSS position data'));
+  });
+
+  it('mentions the filtered source in the error when filterSource is set', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig({ filterSource: 'can0.2' }));
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.performHealthCheck(NOW - 1_000_000, null, onError, onHealthy);
+
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining("source 'can0.2'"));
+    expect(onHealthy).not.toHaveBeenCalled();
+  });
+
+  it('null-source error mentions the filtered source', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig({ filterSource: 'can0.2' }));
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.performHealthCheck(null, null, onError, onHealthy);
+
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining("'can0.2'"));
+  });
+});
+
+describe('HealthMonitor.performInitialCheck', () => {
+  it('errors when no position has ever been received', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig());
+    const onError = jest.fn();
+
+    monitor.performInitialCheck(null, null, onError);
+
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('after 2 minutes'));
+  });
+
+  it('mentions the filtered source on initial-check failure', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig({ filterSource: 'can0.2' }));
+    const onError = jest.fn();
+
+    monitor.performInitialCheck(null, null, onError);
+
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining("'can0.2'"));
+  });
+
+  it('does nothing when a position has been received', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig());
+    const onError = jest.fn();
+
+    monitor.performInitialCheck(Date.now(), null, onError);
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('HealthMonitor.start/stop', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('schedules an initial check after 2 minutes and a periodic check every 5', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig());
+    const onError = jest.fn();
+    const onHealthy = jest.fn();
+
+    monitor.start(
+      () => null,
+      () => null,
+      onError,
+      onHealthy
+    );
+
+    jest.advanceTimersByTime(2 * 60 * 1000);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(5 * 60 * 1000);
+    expect(onError).toHaveBeenCalledTimes(2);
+
+    monitor.stop();
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() is safe to call without start()', () => {
+    const app = createMockApp();
+    const monitor = new HealthMonitor(app, makeConfig());
+    expect(() => {
+      monitor.stop();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #38.

## Why

The position-staleness check in `HealthMonitor` used a hardcoded 300 s threshold while the position subscription is throttled at `minPeriod = trackFrequency * 1000 ms`. For any user with `trackFrequency >= 150 s` the threshold trips routinely on a perfectly healthy GNSS, surfacing "No GNSS position data" errors and flapping `noforeignland.status_boolean`. @philseeley hit this with `trackFrequency: 600` — the logged "599 s / 600 s" gaps line up exactly with the throttle window.

## What

- `HealthMonitor` now derives its staleness threshold from `trackFrequency`: `max(300 s, trackFrequency * 2 + 60 s)` — one full delivery window of headroom on top of the configured cadence.
- Pure helper `computeStaleThresholdSeconds()` is exported so the math is testable.
- New `test/unit/HealthMonitor.test.ts` covers the regression, the legacy path, the filtered-source branches, `performInitialCheck`, and `start`/`stop` lifecycle.
- README + AGENTS.md no longer claim `notifications.noforeignland.status_boolean` is auto-created — the plugin emits no `notifications.*` deltas. README now points users to a Zones rule on `noforeignland.status_boolean` if they want a real notification.

## Tested

- `npm run validate` (typecheck + lint + coverage) — passes; coverage 100 % stmts / 96.55 % branches / 100 % funcs.
- `npm run format:check` — clean.
- `npm run build` — emits `dist/index.{js,d.ts}`.
- Regression test: `performHealthCheck` with `trackFrequency: 600` and a 599 s gap no longer fires `onError` (it did on `main`).
- `cr review --plain` — no findings.