### PR TITLE
chore(release): 1.3.2-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.2-beta.1
+* FIX: HealthMonitor staleness threshold is now derived from `trackFrequency` (`max(300s, trackFrequency * 2 + 60s)`) so the false-positive "No GNSS position data" error and flapping `noforeignland.status_boolean` no longer trip on a healthy GNSS when `trackFrequency` is large. Most-affected setups: `trackFrequency >= 150s`. (#38, #39)
+* DOCS: README and AGENTS.md no longer claim `notifications.noforeignland.status_boolean` is auto-created — the plugin emits no `notifications.*` deltas. README now points users at a Zones rule on `noforeignland.status_boolean` if they want a real notification. (#39)
+
 1.3.1
 * CHANGE: Bump cron 3 → 4 for Node 24 compatibility (#31)
 * CHANGE: Attach `cause` to thrown errors in DirectoryUtils and TrackSender for better diagnostics (#34)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noforeignland/signalk-to-noforeignland",
-  "version": "1.3.1",
+  "version": "1.3.2-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noforeignland/signalk-to-noforeignland",
-      "version": "1.3.1",
+      "version": "1.3.2-beta.1",
       "license": "MIT",
       "dependencies": {
         "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "./doc/screenshots/2_nfl_phone-7.jpg"
     ]
   },
-  "version": "1.3.1",
+  "version": "1.3.2-beta.1",
   "description": "SignalK track logger to noforeignland.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Pre-release of the HealthMonitor fix from #39.

Tag `v1.3.2-beta.1` after merge to trigger `publish.yml`, which publishes under the `beta` dist-tag on npm and marks the GitHub release as prerelease.

## Tested

- `npm run validate` and `npm run build` on the fix commit — clean.
- Version + CHANGELOG bump only; no source changes in this PR.