### PR TITLE
fix(sender): surface diagnostic code when fetch reason is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,8 @@ jspm_packages
 .DS_Store
 *.db
 
+# Local scratch dir (cr review output, agent notes, diffs)
+.scratch/
+
 #npm packaged files
 *.tgz

--- a/src/lib/TrackSender.ts
+++ b/src/lib/TrackSender.ts
@@ -9,6 +9,7 @@ import fetch, { Headers } from 'node-fetch';
 import type { SignalKApp, FlatConfig, SavedPosition, TrackData, NFLApiResponse } from '../types';
 import { NFL_PLUGIN_API_KEY, NFL_API_URL } from '../types/api';
 import { isValidLatitude, isValidLongitude } from '../utils/validation';
+import { describeFetchError } from '../utils/errors';
 
 /**
  * Custom error class to distinguish retryable from non-retryable errors
@@ -162,11 +163,13 @@ export class TrackSender {
         // Network errors are retryable, API errors depend on the error type
         const shouldRetry = err instanceof ApiError ? err.retryable : true;
 
-        // Replace cryptic node-fetch AbortError message with a human-readable one
+        // Replace cryptic node-fetch AbortError message with a human-readable one.
+        // For other network failures, describeFetchError fills in the diagnostic
+        // code when node-fetch left the FetchError reason blank (issue #44).
         const message =
           error.name === 'AbortError'
             ? `Request timed out after ${String((baseTimeout * attempt) / 1000)}s`
-            : error.message;
+            : describeFetchError(err);
 
         this.app.debug(`Attempt ${String(attempt)} failed:`, message);
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Error-message helpers for network failures.
+ *
+ * node-fetch v2 builds its FetchError message as
+ * `request to ${url} failed, reason: ${systemError.message}`. For many
+ * low-level socket failures (ECONNRESET, premature close, socket hang up)
+ * the wrapped system error carries an empty `.message`, so the reason comes
+ * out blank and the user sees `...failed, reason: ` with nothing useful.
+ * The diagnostic code (ECONNRESET, ETIMEDOUT, ENOTFOUND, …) lives on the
+ * FetchError's own `.code` / `.errno` / `.type` fields instead.
+ */
+
+interface FetchErrorLike {
+  message: string;
+  code?: unknown;
+  errno?: unknown;
+  type?: unknown;
+}
+
+function isFetchErrorLike(err: unknown): err is FetchErrorLike {
+  return typeof err === 'object' && err !== null && 'message' in err;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Produce a human-readable, non-empty description of a thrown error.
+ *
+ * If the error is a node-fetch FetchError whose reason is blank, the
+ * diagnostic code from `.code` / `.errno` / `.type` is substituted in so the
+ * status the user sees is actionable instead of empty.
+ */
+export function describeFetchError(err: unknown): string {
+  if (!isFetchErrorLike(err)) {
+    return 'Unknown error';
+  }
+
+  const message = err.message;
+  const trimmed = message.trimEnd();
+
+  // Only intervene when the message ends with a blank reason.
+  if (!trimmed.endsWith('reason:')) {
+    return message.length > 0 ? message : 'Unknown error';
+  }
+
+  const detail =
+    asNonEmptyString(err.code) ?? asNonEmptyString(err.errno) ?? asNonEmptyString(err.type);
+
+  return detail
+    ? `${trimmed} ${detail}`
+    : `${trimmed} connection error (no further detail from the network layer)`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,6 @@
  * Utility exports
  */
 
+export * from './errors';
 export * from './geo';
 export * from './validation';

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -1,0 +1,60 @@
+import { describeFetchError } from '../../src/utils/errors';
+
+describe('describeFetchError', () => {
+  const URL = 'https://www.noforeignland.com/home/api/v1/boat/tracking/track';
+
+  function fetchError(reason: string, extras: Record<string, unknown> = {}): Error {
+    const err = new Error(`request to ${URL} failed, reason: ${reason}`);
+    return Object.assign(err, extras);
+  }
+
+  it('substitutes the .code when the reason is blank (issue #44 signature)', () => {
+    const err = fetchError('', { code: 'ECONNRESET', errno: 'ECONNRESET', type: 'system' });
+    expect(describeFetchError(err)).toBe(`request to ${URL} failed, reason: ECONNRESET`);
+  });
+
+  it('falls back to .errno when .code is absent', () => {
+    const err = fetchError('', { errno: 'ETIMEDOUT' });
+    expect(describeFetchError(err)).toBe(`request to ${URL} failed, reason: ETIMEDOUT`);
+  });
+
+  it('falls back to .type when neither .code nor .errno is present', () => {
+    const err = fetchError('', { type: 'system' });
+    expect(describeFetchError(err)).toBe(`request to ${URL} failed, reason: system`);
+  });
+
+  it('emits a generic detail when no diagnostic field is available', () => {
+    const err = fetchError('');
+    expect(describeFetchError(err)).toBe(
+      `request to ${URL} failed, reason: connection error (no further detail from the network layer)`
+    );
+  });
+
+  it('leaves a non-blank reason untouched', () => {
+    const err = fetchError('getaddrinfo ENOTFOUND www.noforeignland.com', { code: 'ENOTFOUND' });
+    expect(describeFetchError(err)).toBe(
+      `request to ${URL} failed, reason: getaddrinfo ENOTFOUND www.noforeignland.com`
+    );
+  });
+
+  it('passes through ordinary error messages', () => {
+    expect(describeFetchError(new Error('HTTP 503 Service Unavailable'))).toBe(
+      'HTTP 503 Service Unavailable'
+    );
+  });
+
+  it('returns a generic label for an empty, non-fetch message', () => {
+    expect(describeFetchError(new Error(''))).toBe('Unknown error');
+  });
+
+  it('handles non-error inputs gracefully', () => {
+    expect(describeFetchError(null)).toBe('Unknown error');
+    expect(describeFetchError(undefined)).toBe('Unknown error');
+    expect(describeFetchError('a string')).toBe('Unknown error');
+  });
+
+  it('ignores non-string diagnostic fields', () => {
+    const err = fetchError('', { code: 42, errno: -4077, type: 'system' });
+    expect(describeFetchError(err)).toBe(`request to ${URL} failed, reason: system`);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #44. The user's status pill shows:

```
ERROR: Failed to send track - request to https://www.noforeignland.com/home/api/v1/boat/tracking/track failed, reason: 
```

with an **empty reason** after `reason:`. Tracking works; sending fails intermittently with no actionable detail.

## Root cause

`node-fetch` v2 builds its `FetchError.message` as `request to ${url} failed, reason: ${systemError.message}`. For the common socket-level failures (`ECONNRESET`, premature close, "socket hang up") the wrapped system error carries an **empty `.message`**, so the reason renders blank. The diagnostic code lives on the FetchError's own `.code` / `.errno` / `.type` fields, which `TrackSender.sendWithRetry` was discarding by using only `error.message`.

Reproduced locally with node-fetch v2's `FetchError` plus an empty-message `ECONNRESET` system error — exact match for the reported string.

The intermittent nature (works ~once/day) is consistent with a transient network/TLS condition rather than a config error.

## Change

- New pure helper `src/utils/errors.ts` — `describeFetchError(err)` substitutes `.code` → `.errno` → `.type` when a FetchError reason is blank, falling back to a generic "connection error" label. Non-blank messages and ordinary errors pass through untouched.
- Wired into `TrackSender.sendWithRetry`, so the `noforeignland.status` delta reports e.g. `...reason: ECONNRESET` instead of empty.
- Exported from `src/utils/index.ts`.
- `chore`: gitignore the local `.scratch/` directory.

This improves diagnosability; it does not by itself stop the intermittent failures. Once a user reports the now-visible code we can decide whether the follow-up is retry tuning or an NFL-server/TLS issue.

## Tested

- `npm run validate` — typecheck + lint + 66 tests pass; `errors.ts` at 100% coverage.
- `npm run format:check` — clean.
- `npm run build` — emits `dist/utils/errors.js`.
- 8 new unit tests in `test/unit/errors.test.ts` covering the issue signature and each fallback path.