### PR TITLE
chore(release): 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-1.3.2-beta.1
+1.3.2
+* FIX: Send failures now report the underlying network error code (e.g. `ECONNRESET`, `ETIMEDOUT`) instead of an empty `request to … failed, reason: ` message, so intermittent upload errors are diagnosable in `noforeignland.status`. (#44, #45)
 * FIX: HealthMonitor staleness threshold is now derived from `trackFrequency` (`max(300s, trackFrequency * 2 + 60s)`) so the false-positive "No GNSS position data" error and flapping `noforeignland.status_boolean` no longer trip on a healthy GNSS when `trackFrequency` is large. Most-affected setups: `trackFrequency >= 150s`. (#38, #39)
 * DOCS: README and AGENTS.md no longer claim `notifications.noforeignland.status_boolean` is auto-created — the plugin emits no `notifications.*` deltas. README now points users at a Zones rule on `noforeignland.status_boolean` if they want a real notification. (#39)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noforeignland/signalk-to-noforeignland",
-  "version": "1.3.2-beta.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noforeignland/signalk-to-noforeignland",
-      "version": "1.3.2-beta.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "./doc/screenshots/2_nfl_phone-7.jpg"
     ]
   },
-  "version": "1.3.2-beta.1",
+  "version": "1.3.2",
   "description": "SignalK track logger to noforeignland.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Promotes the `1.3.2-beta.1` prerelease to the stable `1.3.2` patch release.

## Included since 1.3.1

- **FIX**: Send failures now report the underlying network error code (e.g. `ECONNRESET`, `ETIMEDOUT`) instead of an empty `request to … failed, reason: ` message, so intermittent upload errors are diagnosable in `noforeignland.status`. (#44, #45)
- **FIX**: HealthMonitor staleness threshold derived from `trackFrequency` so a healthy GNSS with large `trackFrequency` no longer trips a false "No GNSS position data" error. (#38, #39)
- **DOCS**: README/AGENTS.md corrected re: `notifications.noforeignland.status_boolean` not being auto-created. (#39)

## Changes in this PR

- `package.json` + `package-lock.json`: `1.3.2-beta.1` → `1.3.2`
- `CHANGELOG.md`: promote the `1.3.2-beta.1` section to `1.3.2` and add the #44 entry

## Release mechanics

npm publish is triggered separately by pushing the `v1.3.2` tag (→ `publish.yml`, OIDC trusted publisher) after this merges.

## Tested

- `npm run validate` — typecheck + lint + 66 tests pass.
- `npm run build` — clean.