### PR TITLE
fix(sender): raise Happy Eyeballs connect timeout for high-latency links

### DIFF
--- a/src/lib/TrackSender.ts
+++ b/src/lib/TrackSender.ts
@@ -3,6 +3,7 @@
  */
 
 import fs from 'fs-extra';
+import https from 'https';
 import path from 'path';
 import readline from 'readline';
 import fetch, { Headers } from 'node-fetch';
@@ -14,6 +15,20 @@ import { describeFetchError } from '../utils/errors';
 /**
  * Custom error class to distinguish retryable from non-retryable errors
  */
+/**
+ * Node >= 20 enables Happy Eyeballs with a 250 ms per-address connect cap.
+ * The NFL API resolves to multiple addresses (Cloudflare dual-stack), so on
+ * high-latency links (cellular/satellite at sea) every connect attempt is
+ * aborted before the TLS handshake can start and fetch fails instantly with
+ * ETIMEDOUT no matter what apiTimeout is set to (issue #44). Keep the
+ * IPv6/IPv4 fallback but give each address a budget that survives slow links;
+ * apiTimeout still bounds the request overall via the AbortController.
+ */
+const httpsAgent = new https.Agent({
+  autoSelectFamily: true,
+  autoSelectFamilyAttemptTimeout: 5000,
+});
+
 class ApiError extends Error {
   readonly retryable: boolean;
 
@@ -133,6 +148,7 @@ export class TrackSender {
           body: params,
           headers: new Headers(headers),
           signal: controller.signal,
+          agent: httpsAgent,
         });
 
         clearTimeout(timeoutId);


### PR DESCRIPTION
## Problem

Since Node 20, `autoSelectFamily` (Happy Eyeballs) is enabled by default and caps every connect attempt at 250 ms per address. The NFL API is Cloudflare dual-stack (2 A + 2 AAAA records), so on high-latency links (cellular/satellite at sea) every attempt is aborted before the TLS handshake completes. fetch then fails instantly with `AggregateError [ETIMEDOUT]` no matter what `apiTimeout` is set to — the cap sits in `net.connect`, below node-fetch, so the AbortController can bound the request but never extend the connect attempt.

This also explains the blank `reason:` in the original 1.3.1 report: `AggregateError` carries an empty `.message`, which node-fetch v2 interpolates into its error string; the `ETIMEDOUT` code only became visible once #45 started surfacing `.code`.

Known upstream issue: nodejs/node#54359, nodejs/node#52216. Node only raised the default to 500 ms in late 2025, which is still too short for satellite links.

## Fix

Pass a dedicated `https.Agent` to fetch with `autoSelectFamily: true` and `autoSelectFamilyAttemptTimeout: 5000`. This keeps the IPv6→IPv4 fallback but gives each address a 5 s connect budget, and makes behavior uniform across Node versions. `apiTimeout` still bounds the request overall via the existing AbortController.

## Tested

- `npm run validate` — typecheck, lint, 66 tests pass, coverage unchanged (100% statements / 98.78% branches)
- `npm run format:check` and `npm run build` — clean, `dist/` artifacts produced
- `cr review --plain` — no findings

Fixes #44