### PR TITLE
feat(sender): send plugin/SK/Node versions with track POST

### DIFF
--- a/src/lib/TrackSender.ts
+++ b/src/lib/TrackSender.ts
@@ -29,6 +29,25 @@ const httpsAgent = new https.Agent({
   autoSelectFamilyAttemptTimeout: 5000,
 });
 
+/**
+ * Read this plugin's own version from package.json once at load. The file sits
+ * two levels above the compiled module (dist/lib/TrackSender.js -> package root),
+ * outside rootDir, so we read it via __dirname rather than importing it. NFL logs
+ * this with each track to tell which plugin/version a boat is uploading from.
+ */
+function readPluginVersion(): string {
+  try {
+    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+const PLUGIN_VERSION = readPluginVersion();
+const NODE_VERSION = process.version;
+
 class ApiError extends Error {
   readonly retryable: boolean;
 
@@ -109,6 +128,9 @@ export class TrackSender {
     params.append('timestamp', String(trackData.timestamp));
     params.append('track', JSON.stringify(trackData.track));
     params.append('boatApiKey', this.options.boatApiKey);
+    params.append('pluginVersion', PLUGIN_VERSION);
+    params.append('skVersion', this.app.config?.version ?? 'unknown');
+    params.append('nodeVersion', NODE_VERSION);
 
     const headers = { 'X-NFL-API-Key': NFL_PLUGIN_API_KEY };
     this.app.debug('sending track to API');

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -17,6 +17,9 @@ export interface TrackPayload {
   timestamp: number;
   track: Array<[number, number, number]>; // [timestamp_ms, lat, lon]
   boatApiKey: string;
+  pluginVersion: string;
+  skVersion: string;
+  nodeVersion: string;
 }
 
 /**
@@ -29,7 +32,12 @@ export interface ApiConfig {
 }
 
 /**
- * NFL Plugin API key (hardcoded)
+ * NFL Plugin API key (hardcoded).
+ *
+ * Please don't reuse this key for other projects — it's shared by every install
+ * of this plugin and is subject to noforeignland.com's rate limits. If you're
+ * building your own integration, contact support@noforeignland.com and request
+ * your own key.
  */
 export const NFL_PLUGIN_API_KEY = '0ede6cb6-5213-45f5-8ab4-b4836b236f97';
 

--- a/src/types/signalk.ts
+++ b/src/types/signalk.ts
@@ -88,6 +88,9 @@ export interface SignalKApp {
   savePluginOptions: (options: PluginConfig, callback: (err?: Error) => void) => void;
   handleMessage: (pluginId: string, delta: Partial<Delta>) => void;
   subscriptionmanager: SubscriptionManager;
+  // Set by signalk-server from its own package.json; absent in older servers
+  // and not guaranteed by @signalk/server-api, so read it defensively.
+  config?: { version?: string };
 }
 
 /**

--- a/test/mocks/signalk-app.ts
+++ b/test/mocks/signalk-app.ts
@@ -6,6 +6,9 @@ import type { SignalKApp, Delta, SubscribeCommand, Unsubscribe } from '../../src
 
 export interface MockAppOptions {
   dataDir?: string;
+  // When set, exposes app.config.version (the Signal K server release). Leave
+  // undefined to model older servers / @signalk/server-api where it's absent.
+  serverVersion?: string;
 }
 
 export interface MockSignalKApp extends SignalKApp {
@@ -65,6 +68,7 @@ export function createMockApp(options: MockAppOptions = {}): MockSignalKApp {
     subscriptionmanager: {
       subscribe: mocks.subscribe,
     },
+    ...(options.serverVersion !== undefined ? { config: { version: options.serverVersion } } : {}),
     _mocks: mocks,
     _triggerDelta: (delta: Delta): void => {
       if (subscribeCallback) {

--- a/test/unit/TrackSender.test.ts
+++ b/test/unit/TrackSender.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the version telemetry added to the track POST.
+ *
+ * NFL stores plugin/SK/Node versions per track to tell which plugin and release
+ * a boat is uploading from. These must travel in the POST *body* (so the server
+ * can persist them per track), not in headers. See the version-telemetry change.
+ */
+
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import fetch, { Headers } from 'node-fetch';
+import { TrackSender } from '../../src/lib/TrackSender';
+import { NFL_PLUGIN_API_KEY } from '../../src/types/api';
+import { createMockApp } from '../mocks/signalk-app';
+import type { FlatConfig } from '../../src/types';
+
+jest.mock('node-fetch', () => {
+  const actual = jest.requireActual<typeof import('node-fetch')>('node-fetch');
+  return {
+    __esModule: true,
+    default: jest.fn(),
+    Headers: actual.Headers,
+  };
+});
+
+const mockFetch = fetch as unknown as jest.MockedFunction<typeof fetch>;
+
+const PKG_VERSION = (
+  JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8')) as {
+    version: string;
+  }
+).version;
+
+function makeConfig(overrides: Partial<FlatConfig> = {}): FlatConfig {
+  return {
+    boatApiKey: 'test-boat-key',
+    minMove: 50,
+    minSpeed: 0,
+    sendWhileMoving: true,
+    ping_api_every_24h: true,
+    trackDir: '/unused',
+    keepFiles: false,
+    trackFrequency: 60,
+    apiCron: '*/10 * * * *',
+    apiTimeout: 30,
+    maxVelocity: 50,
+    ...overrides,
+  };
+}
+
+function okResponse(): Awaited<ReturnType<typeof fetch>> {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve({ status: 'ok' }),
+  } as unknown as Awaited<ReturnType<typeof fetch>>;
+}
+
+function errorResponse(status: number, statusText: string): Awaited<ReturnType<typeof fetch>> {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve({ status: 'error' }),
+  } as unknown as Awaited<ReturnType<typeof fetch>>;
+}
+
+/** Pull the URLSearchParams body out of the single fetch call. */
+function sentBody(): URLSearchParams {
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const init = mockFetch.mock.calls[0][1];
+  return init?.body as URLSearchParams;
+}
+
+describe('TrackSender version telemetry', () => {
+  let trackDir: string;
+
+  beforeEach(async () => {
+    trackDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nfl-tracksender-'));
+    await fs.writeFile(
+      path.join(trackDir, 'pending.jsonl'),
+      JSON.stringify({ lat: 52.1, lon: 4.3, t: '2026-06-23T10:00:00.000Z' }) + '\n'
+    );
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+  });
+
+  afterEach(async () => {
+    await fs.remove(trackDir);
+  });
+
+  it('puts pluginVersion, skVersion and nodeVersion in the POST body', async () => {
+    const app = createMockApp({ serverVersion: '2.14.0' });
+    const sender = new TrackSender(app, makeConfig(), trackDir);
+
+    const ok = await sender.sendTrack();
+    expect(ok).toBe(true);
+
+    const body = sentBody();
+    expect(body.get('pluginVersion')).toBe(PKG_VERSION);
+    expect(body.get('skVersion')).toBe('2.14.0');
+    expect(body.get('nodeVersion')).toBe(process.version);
+  });
+
+  it('still sends the original timestamp, track and boatApiKey fields', async () => {
+    const app = createMockApp({ serverVersion: '2.14.0' });
+    const sender = new TrackSender(app, makeConfig(), trackDir);
+
+    await sender.sendTrack();
+
+    const body = sentBody();
+    expect(body.get('boatApiKey')).toBe('test-boat-key');
+    expect(body.get('timestamp')).not.toBeNull();
+    expect(body.get('track')).not.toBeNull();
+  });
+
+  it('falls back to "unknown" skVersion when the server exposes no version', async () => {
+    const app = createMockApp(); // no config.version
+    const sender = new TrackSender(app, makeConfig(), trackDir);
+
+    await sender.sendTrack();
+
+    expect(sentBody().get('skVersion')).toBe('unknown');
+  });
+
+  it('keeps version fields out of the request headers (body-only contract)', async () => {
+    const app = createMockApp({ serverVersion: '2.14.0' });
+    const sender = new TrackSender(app, makeConfig(), trackDir);
+
+    await sender.sendTrack();
+
+    const init = mockFetch.mock.calls[0][1];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('X-NFL-API-Key')).toBe(NFL_PLUGIN_API_KEY);
+    expect(headers.get('pluginVersion')).toBeNull();
+    expect(headers.get('skVersion')).toBeNull();
+    expect(headers.get('nodeVersion')).toBeNull();
+  });
+});
+
+describe('TrackSender send behaviour', () => {
+  let trackDir: string;
+
+  beforeEach(async () => {
+    trackDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nfl-tracksender-'));
+    await fs.writeFile(
+      path.join(trackDir, 'pending.jsonl'),
+      JSON.stringify({ lat: 52.1, lon: 4.3, t: '2026-06-23T10:00:00.000Z' }) + '\n'
+    );
+    mockFetch.mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.remove(trackDir);
+  });
+
+  it('throws when no boat API key is configured', async () => {
+    const sender = new TrackSender(createMockApp(), makeConfig({ boatApiKey: '' }), trackDir);
+    await expect(sender.sendTrack()).rejects.toThrow('No boat API key');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when the pending file has no valid track points', async () => {
+    await fs.writeFile(path.join(trackDir, 'pending.jsonl'), 'not json\n');
+    const sender = new TrackSender(createMockApp(), makeConfig(), trackDir);
+    await expect(sender.sendTrack()).rejects.toThrow('did not contain any valid track points');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a 4xx response and surfaces the error', async () => {
+    mockFetch.mockResolvedValue(errorResponse(401, 'Unauthorized'));
+    const sender = new TrackSender(createMockApp(), makeConfig(), trackDir);
+    await expect(sender.sendTrack()).rejects.toThrow('401');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 5xx response up to the retry limit', async () => {
+    // sendWithRetry backs off 2000ms * attempt between tries (~6s total), so this
+    // test needs a longer timeout than the 5s jest default to see all 3 attempts.
+    mockFetch.mockResolvedValue(errorResponse(503, 'Service Unavailable'));
+    const sender = new TrackSender(createMockApp(), makeConfig(), trackDir);
+    await expect(sender.sendTrack()).rejects.toThrow('503');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  }, 15000);
+
+  it('archives the pending file to sent.jsonl when keepFiles is on', async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    const sender = new TrackSender(createMockApp(), makeConfig({ keepFiles: true }), trackDir);
+
+    const ok = await sender.sendTrack();
+    expect(ok).toBe(true);
+
+    expect(await fs.pathExists(path.join(trackDir, 'pending.jsonl'))).toBe(false);
+    const sent = await fs.readFile(path.join(trackDir, 'sent.jsonl'), 'utf8');
+    expect(sent).toContain('52.1');
+  });
+});


### PR DESCRIPTION
## What

Send three version fields with each track upload, and add a note above the shared plugin API key.

- **Version telemetry.** The track POST now includes `pluginVersion` (this plugin's version, read from `package.json`), `skVersion` (the Signal K server release, from `app.config.version`), and `nodeVersion` (`process.version`) as body fields alongside the existing `timestamp` / `track` / `boatApiKey`. This lets noforeignland.com record which plugin and release a boat is uploading from — in particular to tell this plugin apart from older forks that use a different API key, and to log SK release usage.
- **API key note.** A short comment above `NFL_PLUGIN_API_KEY` asks integrators building their own projects to request their own key (support@noforeignland.com) rather than reusing the shared one, which is subject to rate limits.

## Why body, not headers

NFL wants to persist the versions per track in their database. Body fields land in the same request their endpoint already parses for the track row, and (unlike headers) can't be silently dropped by a proxy before reaching the app.

## Notes

- All three versions are read defensively and fall back to `"unknown"` if unavailable (e.g. older servers that don't expose `app.config.version`, or a read-only filesystem).
- `app.config.version` is set by the Signal K server from its own `package.json`; it isn't part of the minimal `SignalKApp` type here, so the type is extended with an optional `config?: { version?: string }` and read with optional chaining.
- The plugin's own version is read via `__dirname` rather than `import`, because `package.json` sits outside `rootDir: ./src` and a direct import would break the build.

## Tested

- `npm run validate` (typecheck + lint + coverage) passes; coverage 89.7% (>80% gate).
- `npm run format:check` passes.
- New `test/unit/TrackSender.test.ts` (75 tests total): asserts the three version fields are in the POST **body** (not headers), the original `timestamp` / `track` / `boatApiKey` fields are still sent, and `skVersion` falls back to `"unknown"` when the server exposes no version. Also covers no-retry-on-4xx, retry-on-5xx, and the `keepFiles` archival path.
- Built (`npm run build`) and confirmed the compiled `dist/lib/TrackSender.js` reads the real plugin version (`1.3.3`, not `"unknown"`) from its installed location.
