### PR TITLE
chore(deps-dev): align @eslint/js with eslint 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.18.0",
+        "@eslint/js": "^10.0.0",
         "@signalk/server-api": "^2.10.0",
         "@tsconfig/node20": "^20.1.4",
         "@types/fs-extra": "^11.0.4",
@@ -678,16 +678,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.18.0",
+    "@eslint/js": "^10.0.0",
     "@signalk/server-api": "^2.10.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
## What

Bump `@eslint/js` from `^9.18.0` to `^10.0.0` and refresh the lockfile.

## Why

PR #41 bumped `eslint` to `^10.5.0` but left `@eslint/js` at `^9.18.0` — a major version behind. The two are meant to track together (eslint 10 pairs with @eslint/js 10), and the installed tree had drifted to eslint 9.39.4 locally while `package.json` declared 10. This aligns the flat-config toolchain on a consistent eslint 10.

## Tested

- `npm install` refreshes to eslint 10.5.0 / @eslint/js 10.0.1 / typescript-eslint 8.61.0.
- `npm run validate` (typecheck + lint + coverage) passes under eslint 10.
- `npm run format:check` passes.