### PR TITLE
chore(deps): pin @types/node to v20 to match Cerbo runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
         update-types: [version-update:semver-major]
       - dependency-name: '@types/node-fetch'
         update-types: [version-update:semver-major]
+      # Keep @types/node aligned with the lowest supported runtime (Node 20 on
+      # Victron Cerbo GX) so TypeScript rejects APIs that don't exist there.
+      # Bumping past 20 lets code typecheck against newer Node APIs that crash
+      # on the boat. See engines.node and @tsconfig/node20.
+      - dependency-name: '@types/node'
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What

Add `@types/node` major-version bumps to the Dependabot ignore list, alongside the existing `node-fetch` pin.

## Why

`@types/node` should describe the **lowest supported runtime** so TypeScript catches use of Node APIs that don't exist there. This plugin runs on the Victron Cerbo GX on **Node 20** (`engines.node >= 18`, `@tsconfig/node20`). Bumping `@types/node` to a newer major (e.g. 26, in #52) lets code typecheck against APIs that aren't present on the boat and would crash at runtime — and CI wouldn't catch it (`skipLibCheck: true`). It's a dev-only dependency, so this is purely about keeping the compile-time floor honest, not about the shipped package.

Closes #52.

## Tested

- Config-only change to `.github/dependabot.yml`; no source or build impact.