### PR TITLE
chore(release): 1.4.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noforeignland/signalk-to-noforeignland",
-  "version": "1.3.3",
+  "version": "1.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noforeignland/signalk-to-noforeignland",
-      "version": "1.3.3",
+      "version": "1.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "./doc/screenshots/2_nfl_phone-7.jpg"
     ]
   },
-  "version": "1.3.3",
+  "version": "1.4.0-beta.1",
   "description": "SignalK track logger to noforeignland.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What

Bump version to `1.4.0-beta.1` for a pre-release.

Minor bump because this release adds a new outbound feature: the track POST now sends `pluginVersion`, `skVersion` and `nodeVersion` so noforeignland.com can record which plugin and release each boat uploads from (#53). Also includes the dependency refresh (eslint 10 alignment #54, server-api/prettier/typescript-eslint #55, actions/checkout 7 #50, @types/node pinned to v20 #56).

CHANGELOG is maintained separately by the maintainer at release time.

## Tested

- Version bumped consistently in package.json and package-lock.json (1.4.0-beta.1).
- `npm run validate` (typecheck + lint + coverage) passes; 75 tests.
- `npm run format:check` passes.
- Version telemetry verified end-to-end against a local capture server: all three version fields arrive in the POST body, with pluginVersion read correctly from the compiled artifact.