### PR TITLE
fix(sender): stop re-uploading delivered tracks on response-read failures

### DIFF
--- a/src/lib/TrackSender.ts
+++ b/src/lib/TrackSender.ts
@@ -165,36 +165,61 @@ export class TrackSender {
           controller.abort();
         }, currentTimeout);
 
-        const response = await fetch(NFL_API_URL, {
-          method: 'POST',
-          body: params,
-          headers: new Headers(headers),
-          signal: controller.signal,
-          agent: httpsAgent,
-        });
+        // The timeout must stay armed until the response body has been read:
+        // a truncated identity body otherwise leaves response.json() pending
+        // forever and the send cron never runs again until a server restart.
+        try {
+          const response = await fetch(NFL_API_URL, {
+            method: 'POST',
+            body: params,
+            headers: new Headers(headers),
+            signal: controller.signal,
+            agent: httpsAgent,
+            // The API reply is a few bytes of JSON; a gzipped reply can die in
+            // node-fetch's Gunzip stream with "Premature close", making a
+            // delivered upload look failed. Don't ask for compression at all.
+            compress: false,
+          });
 
-        clearTimeout(timeoutId);
-
-        if (response.ok) {
-          const responseBody = (await response.json()) as NFLApiResponse;
-          if (responseBody.status === 'ok') {
-            this.app.debug('Track successfully sent to API');
-            return true;
+          if (response.ok) {
+            let responseBody: NFLApiResponse;
+            try {
+              responseBody = (await response.json()) as NFLApiResponse;
+            } catch (bodyErr) {
+              // Any 2xx means the server already accepted and stored the
+              // track. Failing to read the response body afterwards must not
+              // count as a failed upload — retrying/resending the pending file
+              // from here is what duplicates the whole track on the NFL map.
+              this.app.debug(
+                `Track delivered (HTTP ${String(response.status)}) but response body could not be read, treating as sent:`,
+                describeFetchError(bodyErr)
+              );
+              return true;
+            }
+            if (responseBody.status === 'ok') {
+              this.app.debug('Track successfully sent to API');
+              return true;
+            } else {
+              // API returned error with message - don't retry, this is a client-side issue
+              const apiMessage = responseBody.message ?? 'Unknown API error';
+              this.app.debug('API returned error:', apiMessage);
+              throw new ApiError(apiMessage, false);
+            }
           } else {
-            // API returned error with message - don't retry, this is a client-side issue
-            const apiMessage = responseBody.message ?? 'Unknown API error';
-            this.app.debug('API returned error:', apiMessage);
-            throw new ApiError(apiMessage, false);
+            this.app.debug(
+              'Could not send track to API, returned response code:',
+              response.status,
+              response.statusText
+            );
+            // 4xx = client error (don't retry), 5xx = server error (retry)
+            const shouldRetry = response.status >= 500;
+            throw new ApiError(
+              `HTTP ${String(response.status)} ${response.statusText}`,
+              shouldRetry
+            );
           }
-        } else {
-          this.app.debug(
-            'Could not send track to API, returned response code:',
-            response.status,
-            response.statusText
-          );
-          // 4xx = client error (don't retry), 5xx = server error (retry)
-          const shouldRetry = response.status >= 500;
-          throw new ApiError(`HTTP ${String(response.status)} ${response.statusText}`, shouldRetry);
+        } finally {
+          clearTimeout(timeoutId);
         }
       } catch (err) {
         const error = err as Error;

--- a/test/unit/TrackSender.test.ts
+++ b/test/unit/TrackSender.test.ts
@@ -185,6 +185,69 @@ describe('TrackSender send behaviour', () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   }, 15000);
 
+  it('requests the response uncompressed (compress: false)', async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    const sender = new TrackSender(createMockApp(), makeConfig(), trackDir);
+
+    await sender.sendTrack();
+
+    const init = mockFetch.mock.calls[0][1];
+    expect(init?.compress).toBe(false);
+  });
+
+  it('treats HTTP 200 with an unreadable body as sent and clears the pending file', async () => {
+    // node-fetch shape of the Gunzip "Premature close" failure: the request was
+    // delivered and the server answered 200, but reading the body throws.
+    const prematureClose = Object.assign(
+      new Error(
+        'Invalid response body while trying to fetch https://example.invalid: Premature close'
+      ),
+      { name: 'FetchError', type: 'system', code: 'ERR_STREAM_PREMATURE_CLOSE' }
+    );
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.reject(prematureClose),
+    } as unknown as Awaited<ReturnType<typeof fetch>>);
+
+    const sender = new TrackSender(createMockApp(), makeConfig(), trackDir);
+
+    const ok = await sender.sendTrack();
+    expect(ok).toBe(true);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(await fs.pathExists(path.join(trackDir, 'pending.jsonl'))).toBe(false);
+  });
+
+  it('aborts a hanging body read via the attempt timeout and treats the 200 as sent', async () => {
+    // The abort timer must stay armed until the body is read; if it is cleared
+    // as soon as fetch() resolves, a body that never arrives leaves sendTrack()
+    // pending forever and the send cron never fires again.
+    mockFetch.mockImplementation((_url, init) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(
+                Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' })
+              );
+            });
+          }),
+      } as unknown as Awaited<ReturnType<typeof fetch>>)
+    );
+
+    const sender = new TrackSender(createMockApp(), makeConfig({ apiTimeout: 1 }), trackDir);
+
+    const ok = await sender.sendTrack();
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(await fs.pathExists(path.join(trackDir, 'pending.jsonl'))).toBe(false);
+  }, 10000);
+
   it('archives the pending file to sent.jsonl when keepFiles is on', async () => {
     mockFetch.mockResolvedValue(okResponse());
     const sender = new TrackSender(createMockApp(), makeConfig({ keepFiles: true }), trackDir);


### PR DESCRIPTION
## Problem

Reported by SV Albertone: the NFL map shows a fan of track lines converging on the boat's old berth in Olbia. His local track files were clean — the duplicates were created by the upload path.

The NFL API answers a track POST with a few bytes of JSON. When that reply is gzipped, node-fetch's Gunzip stream can die with `ERR_STREAM_PREMATURE_CLOSE` ("Invalid response body … Premature close") even though the request was fully delivered and the server answered HTTP 200 and stored the track. The sender treated this as a failed attempt, retried twice, and never cleared `pending.jsonl` — so the whole growing track file (which still starts at the old berth) was re-delivered every cron cycle. Each server-side copy runs …route point → old berth → route point…, which draws exactly the observed fan.

His log shows this failing on every send since June 19: 3× `Premature close` per cycle, `sent.jsonl` frozen at the last acknowledged upload, `pending.jsonl` growing past 750 points.

## Fix

- Request the response uncompressed (`compress: false`). The reply is tiny, so compression buys nothing, and the Gunzip failure path is never entered.
- Treat a 2xx response with an unreadable body as sent. The server has already accepted the track at that point; retrying/resending from there is what duplicates it on the map.
- Keep the attempt timeout armed until the body has been read (previously it was cleared as soon as `fetch()` resolved). A truncated identity body used to leave `response.json()` pending forever, silently freezing the send cron until a server restart.

Independent of this fix, the server could dedupe track points per boat/timestamp on ingest, which would also self-heal tracks already polluted by old plugin versions.

## Tested

- `npm run validate` (typecheck, lint, jest: 78 tests) and `npm run format:check` pass.
- End-to-end repro against a local HTTPS server that mimics the observed behaviour (gzips the reply when the client allows it, then closes the socket mid-stream): the old defaults reproduce the exact production error (`200 OK` received, client sees `Premature close`, server-side upload complete), the fixed sender uploads cleanly and clears `pending.jsonl`, and a 200-with-truncated-body is bounded by the attempt timeout and treated as sent instead of hanging.
- `cr review --plain` run locally; its one finding (2xx vs 200 in the fallback) was addressed by aligning the comment and log wording — any 2xx intentionally counts as delivered.