### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noforeignland/signalk-to-noforeignland",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noforeignland/signalk-to-noforeignland",
-      "version": "1.4.0-beta.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "./doc/screenshots/2_nfl_phone-7.jpg"
     ]
   },
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0",
   "description": "SignalK track logger to noforeignland.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Stable release from main, promoting the 1.4.0 beta line.

Ships since 1.3.3:

- feat(sender): send plugin/SK/Node versions with each track POST (#53)
- fix(sender): stop re-uploading delivered tracks on response-read failures (#60) — the "fan of duplicate track lines" bug
- dependency bumps (checkout v7, grouped minor/patch)

After merge I'll tag `v1.4.0`, which triggers publish.yml (npm `latest` + GitHub Release).